### PR TITLE
Added :align property support to :heading and :paragraph elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ tag :heading
 optional metadata:
 
 * :heading-style specifies the font for the heading
+* :align specifies alignement of heading possible valuse "left|center|right"
 
 ```clojure
 [:heading "Lorem Ipsum"]
@@ -277,6 +278,7 @@ optional metadata:
 * :indent number
 * :keep-together boolean
 * :leading number
+* :align "left|center|right"
 
 content:
 

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -129,20 +129,26 @@
 (defn- heading [meta & content]
   (let [style (if (contains? meta :heading-style)
                 (rename-keys meta {:heading-style :style})
-                {:style {:size 18 :style "bold"}})]
-    (make-section (into [:paragraph style] content))))
+                {:style {:size 18 :style "bold"}})
+        align (if (contains? meta :align)
+                [:align (:align meta)]
+                [:align "left"])
+        attrs (conj style align)]
+    (make-section (into [:paragraph attrs] content))))
 
 
 (defn- paragraph [{indent        :indent
                    style         :style
                    keep-together :keep-together
-                   leading       :leading} content]
+                   leading       :leading
+                   align         :align} content]
   (let [paragraph (if style
                     (new Paragraph (make-section content) (font style))
                     (new Paragraph (make-section content)))]
     (if keep-together (.setKeepTogether paragraph true))
     (if indent (.setFirstLineIndent paragraph (float indent)))
     (if leading (.setLeading paragraph (float leading)))
+    (if align (.setAlignment paragraph (get-alignment align)))
     paragraph ))
 
 

--- a/test/clj_pdf/test/core.clj
+++ b/test/clj_pdf/test/core.clj
@@ -103,7 +103,8 @@
   (eq? [{}
        [:paragraph "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse convallis blandit justo non rutrum. In hac habitasse platea dictumst."]
        [:paragraph {:indent 50} [:phrase {:style "bold" :size 18 :family "halvetica" :color [0 255 221]} "Hello Clojure!"]]
-       [:paragraph {:keep-together true :indent 20} "a fine paragraph"]]
+       [:paragraph {:keep-together true :indent 20} "a fine paragraph"]
+       [:paragraph {:align "center"} "centered paragraph"]]
       "paragraph.pdf"))
 
 (deftest list-test
@@ -134,7 +135,8 @@
 
 (deftest heading
   (eq? [{} [:heading "Lorem Ipsum"]    
-       [:heading {:heading-style {:size 15}} "Lorem Ipsum"]]
+       [:heading {:heading-style {:size 15}} "Lorem Ipsum"]
+       [:heading {:align "center"} "Centered"]]
       "heading.pdf"))
 
 


### PR DESCRIPTION
Currently it is impossible to define alignment of heading and paragraph elements. This patch set adds support for :align property to mentioned above elements
