### PR TITLE
Support PdfPTables and add support for events

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,5 +8,4 @@
             :comments "same as  iText and JFreeChart"}
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [jfree/jfreechart "1.0.13"]                 
-                 [itext-min "0.2"]
-                 [org.clojure/tools.logging "0.2.6"]])
+                 [itext-min "0.2"]])

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -1,7 +1,6 @@
 (ns clj-pdf.core
   (:use clojure.walk [clojure.set :only (rename-keys)])
-  (:require [clj_pdf.charting :as charting]
-            [clojure.tools.logging :refer [info error]])
+  (:require [clj_pdf.charting :as charting])
   (:import
     java.awt.Color
     [com.lowagie.text.pdf.draw DottedLineSeparator LineSeparator]  


### PR DESCRIPTION
Im happy to tidy this up a bit more if you like the changes.

Added the option to set page events, which provides another way to set the page number.
Added the option to set table events and PdfPTables. I have a PdfPTable event that provides alternating background. I could write these vents as generated classes for examples.
I moved setMargins before opening the doc in setup-doc (won't work otherwise)
