### PR TITLE
Specify false for the footer in document metadata to disable the footer completely.

### DIFF
--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -618,10 +618,11 @@
         height        (.. doc getPageSize getHeight)
         output-stream (if (string? out) (new FileOutputStream out) out)
         temp-stream   (if (or pages (not (empty? page-events))) (new ByteArrayOutputStream))
-        footer        (if (string? footer)
-                        {:text footer :align :right :start-page 1}          
-                        (merge {:align :right :start-page 1} footer))]
- 
+        footer        (when (not= footer false)
+                        (if (string? footer)
+                          {:text footer :align :right :start-page 1}
+                          (merge {:align :right :start-page 1} footer)))]
+
     ;;header and footer must be set before the doc is opened, or itext will not put them on the first page!
     ;;if we have to print total pages, then the document has to be post processed
     (let [output-stream-to-use (if (or pages (not (empty? page-events))) temp-stream output-stream)]
@@ -684,19 +685,21 @@
         stamper   (new PdfStamper reader, output-stream)
         num-pages (.getNumberOfPages reader)
         base-font (BaseFont/createFont)
-        footer    (if (string? footer)
-                    {:text footer :align :right :start-page 1}
-                    (merge {:align :right :start-page 1} footer))]    
-    (dotimes [i num-pages]
-      (if (>= i (dec (or (:start-page footer) 1)))
-        (doto (.getOverContent stamper (inc i))
-          (.beginText)
-          (.setFontAndSize base-font 10)        
-          (.setTextMatrix
-            (align-footer width base-font footer) (float 20))        
+        footer    (when (not= footer false)
+                    (if (string? footer)
+                      {:text footer :align :right :start-page 1}
+                      (merge {:align :right :start-page 1} footer)))]
+    (when footer
+      (dotimes [i num-pages]
+        (if (>= i (dec (or (:start-page footer) 1)))
+          (doto (.getOverContent stamper (inc i))
+            (.beginText)
+            (.setFontAndSize base-font 10)        
+            (.setTextMatrix
+             (align-footer width base-font footer) (float 20))        
           
-          (.showText (str (:text footer) " " (inc i) (or (:footer-separator footer) " / ") num-pages))
-          (.endText))))
+            (.showText (str (:text footer) " " (inc i) (or (:footer-separator footer) " / ") num-pages))
+            (.endText)))))
     (.close stamper)))
  
 

--- a/test/clj_pdf/test/core.clj
+++ b/test/clj_pdf/test/core.clj
@@ -59,6 +59,27 @@
      [:chunk "meta test"]]
     "pages2.pdf"))
 
+(deftest no-footer
+  (eq?
+   [{:title  "Test doc"
+      :left-margin   10
+      :right-margin  50
+      :top-margin    20
+      :bottom-margin 25
+      :pages true
+      :font  {:size 11}  
+      :size          :a4
+      :orientation   "landscape"
+      :subject "Some subject"
+      :author "John Doe"
+      :creator "Jane Doe"
+      :doc-header ["inspired by" "William Shakespeare"]
+      :header "page header"
+      :footer false}
+     [:paragraph "I should have font size 11"]
+     [:chunk "meta test"]]
+   "nofooter.pdf"))
+
 (deftest image
   (eq? 
     [{}      

--- a/test/nofooter.pdf
+++ b/test/nofooter.pdf
@@ -1,0 +1,39 @@
+%PDF-1.4
+%����
+1 0 obj
+<</BaseFont/Helvetica/Type/Font/Subtype/Type1/Encoding/WinAnsiEncoding>>
+endobj
+2 0 obj
+<</Length 166/Filter/FlateDecode>>stream
+x�e���@E���:%�����&2�Dj��[��L���M���
+:��%�b
+�W�+
+#:�&%�z��h+V��<������ِ���.��$4:��!s6v��䂨/�^J��F�Ii�F�U�"Ff/Iu��nN��b�w�-]gѹ��AF޸�5<D
+endstream
+endobj
+3 0 obj
+<</ITXT(4.2.0)/Type/Pages/Count 1/Kids>>
+endobj
+4 0 obj
+<</Parent 3 0 R/Type/Page/Contents 2 0 R/Resources<</ProcSet/Font<</F1 1 0 R>>>>/MediaBox/Rotate 90>>
+endobj
+5 0 obj
+<</Type/Catalog/Pages 3 0 R>>
+endobj
+6 0 obj
+<</Creator(Jane Doe)/Producer(iText 4.2.0 by 1T3XT)/inspired#20by(William Shakespeare)/Title(Test doc)/Subject(Some subject)//Author(John Doe)/>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000103 00000 n 
+0000000336 00000 n 
+0000000399 00000 n 
+0000000561 00000 n 
+0000000606 00000 n 
+trailer
+<</Root 5 0 R/ID /Info 6 0 R/Size 7>>
+startxref
+836
+%%EOF


### PR DESCRIPTION
Thanks for this excellent library!

Currently it appears that there is no way to completely disable the footer (if `nil` is specified for footer, then the page number always appears in the bottom right of every page). This pull request allows you to specify `false` for the footer metadata option to completely disable the footer.
