### PR TITLE
only search for classes if a stylesheet is provided

### DIFF
--- a/src/clj/clj_pdf/section.clj
+++ b/src/clj/clj_pdf/section.clj
@@ -32,12 +32,12 @@
        (let [[tag & content]  element
              tag              (keywordize tag)
              [tag & classes]  (split-classes-from-tag tag)
-             class-attrs      (get-class-attributes (:stylesheet meta) classes)
              [attrs elements] (if (map? (first content))
                                 [(first content) (rest content)]
                                 [nil content])
+             stylesheet       (:stylesheet meta)
              new-meta         (cond-> meta
-                                class-attrs (merge class-attrs)
+                                stylesheet  (merge (get-class-attributes stylesheet classes))
                                 attrs       (merge attrs))]
 
          (apply render tag new-meta elements)))

--- a/test/clj_pdf/test/core.clj
+++ b/test/clj_pdf/test/core.clj
@@ -308,3 +308,7 @@
   (eq? [{}
         nil]
        "nil.pdf"))
+
+(deftest nil-stylesheet-no-npe
+  (is (pdf->bytes [{:stylesheet nil}
+                   [:paragraph.custom "Styled"]])))


### PR DESCRIPTION
fixes #159 

While in #159 the root cause was described as a missing class I think it's actually a nil stylesheet that will cause the NPE when `(map stylesheet class)` is called.

All of the following invocations should now work fine:

```clojure
(pdf
 [{:stylesheet {:custom {:size 40}}}
  [:phrase.custom "Styled"]]
 "test.pdf")

;; worked
(pdf
 [{:stylesheet {:wrong {:size 10}}}
  [:phrase.custom "Styled"]]
 "test.pdf")

;; failed, works now
(pdf
 [{}
  [:phrase.custom "Styled"]]
 "test.pdf")

;; failed, works now
(pdf
 [nil
  [:phrase.custom "Styled"]]
 "test.pdf")

;; failed, works now
(pdf
 [{:stylesheet nil}
  [:phrase.custom "Styled"]]
 "test.pdf")
```

About the code:

- The fallback could also be handled in `get-class-attributes` (?)
- I'm not sure what the `cond->` in line 39 is good for since merging nil is the same as not merging anything.