### PR TITLE
Bind *pdf-writer* for seq doc

### DIFF
--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -531,8 +531,9 @@
          ^ByteArrayOutputStream temp-stream
          ^OutputStream output-stream
          ^PdfWriter pdf-writer] (setup-doc doc-meta out)]
-    (doseq [item (rest items)]
-      (add-item item doc-meta width height doc pdf-writer))
+    (binding [*pdf-writer* pdf-writer]
+      (doseq [item (rest items)]
+        (add-item item doc-meta width height doc pdf-writer)))
     (.close doc)
     (write-total-pages width doc-meta temp-stream output-stream)))
 


### PR DESCRIPTION
When generating a document from a seq, it is useful to have access to the underlaying `PdfWriter` to get e.g. vertical position on a page. An example use case is in #110.

`*pdf-writer*` was already defined and I'm just binding it.