### PR TITLE
Fix image chunks for images that don't implement ImgRaw

### DIFF
--- a/src/clj/clj_pdf/section/core.clj
+++ b/src/clj/clj_pdf/section/core.clj
@@ -6,7 +6,7 @@
             [clj-pdf.graphics-2d :as g2d]
             [clj-pdf.section :refer [render *cache* make-section make-section-or]])
   (:import [com.lowagie.text
-            Anchor Annotation ChapterAutoNumber Chunk Font ImgRaw Image
+            Anchor Annotation ChapterAutoNumber Chunk Font Image
             List GreekList RomanList ListItem Paragraph Phrase Rectangle Section
             ZapfDingbatsList ZapfDingbatsNumberList]
            [com.lowagie.text.pdf MultiColumnText]
@@ -71,7 +71,7 @@
 (defmethod render :chunk
   [_ meta content]
   (let [children (make-section content)]
-    (if (instance? ImgRaw children)
+    (if (instance? Image children)
       (image-chunk meta children)
       (text-chunk meta children))))
 


### PR DESCRIPTION
We're seeing a failure inside a chunk where we simply switched the image from `.png` to `.jpg`.

After some investigation, I realized that `make-image` returns a `com.lowagie.text.Jpeg` for JPEGs but `com.lowagie.text.ImgRaw` for PNGs.

I tried writing a test but it seems like none of the tests are actually working, so I gave up. Our failing case is literally:

```clojure
[:chunk
 {:width 20
  :height 20}
 [:image {} (resource/resource "hi.jpg")]]
```