### PR TITLE
tolerate empty lists at the document top level

### DIFF
--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -468,7 +468,7 @@
     :else item))
 
 (defn- add-item [item {:keys [stylesheet font references]} width height ^Document doc ^PdfWriter pdf-writer]
-  (if (and (coll? item) (coll? (first item)))
+  (if (seq? item)
     (doseq [element item]
       (append-to-doc stylesheet references font width height (preprocess-item element) doc pdf-writer))
     (append-to-doc stylesheet references font width height (preprocess-item item) doc pdf-writer)))

--- a/test/clj_pdf/test/core.clj
+++ b/test/clj_pdf/test/core.clj
@@ -330,6 +330,13 @@
        "nil.pdf"
        :stream false))
 
+(deftest empty-list
+  (eq? [{}
+        nil
+        (list)]
+       "nil.pdf"
+       :stream false))
+
 (deftest nil-stylesheet-no-npe
   (is (pdf->bytes [{:stylesheet nil}
                    [:paragraph.custom "Styled"]])))


### PR DESCRIPTION
use (seq? item) to identify items to iterate over, just like hiccup
does

fixes the first part of #185