### PR TITLE
Allow to pass under in watermark meta

### DIFF
--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -231,11 +231,11 @@
   (let [image (some-> (-> meta :watermark :image) buffered-image)]
     (proxy [PdfPageEventHelper] []
       (onEndPage [writer doc]
-        (let [{:keys [scale rotate translate] :as wm} (:watermark meta)]
+        (let [{:keys [scale rotate translate under] :or {under true} :as wm} (:watermark meta)]
           (g2d/with-graphics
             (assoc meta
               :pdf-writer writer
-              :under true
+              :under under
               :scale scale
               :rotate rotate
               :translate translate)


### PR DESCRIPTION
This is to prevent some case where the watermark can be under a table.