### PR TITLE
Don't try to render header when there's no header content

### DIFF
--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -171,7 +171,8 @@
     (onEndPage [^PdfWriter writer ^Document doc]
       (let [page-num     (.getPageNumber doc)
             first-page?  (= page-num 1)
-            show-header? (or (not first-page?) header-first-page?)
+            show-header? (and (boolean header-content)
+                              (or (not first-page?) header-first-page?))
             show-footer? (boolean footer-content)]
 
         ;; set top margin ready for header on next page


### PR DESCRIPTION
I don't know if this is a sufficient fix for #220 - there might be other concerns I do not see, but it does seem to work for me. Accept it if you want, or please provide feedback so I can make it better.