### PR TITLE
Add metadata keywords option for pdf documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ of inputstream, file name, url, or a byte array.
 (collate {:title "collated documents"
           :author "john doe"
           :creator "jane doe"
+          :keywords "jane,school,notes"
           :orientation :landscape
           :size :a4
           :subject "some subject"}
@@ -296,6 +297,7 @@ all fields in the metadata section are optional:
  :subject "some subject"
  :size          :a4
  :orientation   :landscape
+ :keywords "those,metadata,keywords,comma,separated,help,with,searching"
  :author "john doe"
  :creator "jane doe"
  :font  {:size 11} ;specifies default font
@@ -1440,6 +1442,7 @@ creating a pdf:
     :doc-header    ["inspired by" "William Shakespeare"]
     :right-margin  50
     :author        "John Doe"
+    :keywords      "jane,subject,school,drama,art"
     :bottom-margin 10
     :left-margin   10
     :top-margin    20

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -347,6 +347,7 @@
                           footer
                           pages
                           author
+                          keywords
                           creator
                           size
                           font-style
@@ -423,6 +424,7 @@
       (when subject (.addSubject doc subject))
       (when (and nom head) (.addHeader doc nom head))
       (when author (.addAuthor doc author))
+      (when keywords (.addKeywords doc keywords))
       (when creator (.addCreator doc creator))
 
       [doc width height temp-stream output-stream pdf-writer])))


### PR DESCRIPTION
I needed keywords metadata on my PDF, it was already supported by the parent java library, so it was a quick update.
