### PR TITLE
WIP: Update CircleCI config to version 2.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/clj-pdf
+    docker:
+      - image: clojure:temurin-21-lein
+    steps:
+      - checkout
+      - restore_cache:
+          key: << checksum "project.clj" >>
+      - run: apt update && apt install -y libfreetype6 fontconfig
+      - run: lein test
+      - save_cache:
+          paths:
+            - $HOME/.m2
+          key: << checksum "project.clj" >>
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pom.xml.asc
 *.iws
 .idea
 profiles.clj
+/.clj-kondo

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  java:
-    version: oraclejdk8


### PR DESCRIPTION
The `circle.yml` file in the repository was based on the old CircleCI 1.0 which was shut down several years ago.

I've updated the config to CircleCI 2.0. However, the build is still failing: 
https://app.circleci.com/pipelines/github/technomancy/clj-pdf/6/workflows/25041072-6025-49ef-ba8c-9572c2ca2e9f/jobs/7

It's unclear to me what the root cause of the failures are.