### PR TITLE
Fixed colspan not affecting column counting for widths

### DIFF
--- a/src/clj/clj_pdf/section/table.clj
+++ b/src/clj/clj_pdf/section/table.clj
@@ -68,6 +68,14 @@
                   :else [:pdf-cell content])]
     (.addCell tbl ^PdfPCell (make-section meta element))))
 
+(defn- spanned-columns-for-cell [cell]
+  (if (and (sequential? cell)
+           (associative? (second cell)))
+    (-> cell second (:colspan 1))
+    1))
+
+(defn- spanned-columns [row]
+  (apply + (map spanned-columns-for-cell row)))
 
 (defmethod render :table
   [_ {:keys [align
@@ -91,7 +99,7 @@
 
   (let [header-cols (cond-> (count header)
                             (map? (first header)) dec)
-        cols        (or num-cols (apply max (cons header-cols (map count rows))))
+        cols        (or num-cols (apply max (cons header-cols (map spanned-columns rows))))
         ^Table tbl  (doto (new Table cols (count rows))
                       (.setWidth (float (or width 100))))]
 

--- a/test/clj_pdf/test/core.clj
+++ b/test/clj_pdf/test/core.clj
@@ -143,7 +143,20 @@
        "baz"]
       ["foo1" [:cell {:color [100 10 200]} "bar1"] "baz1"]
       ["foo2" "bar2" "baz2"]]]
-    "table.pdf"))
+    "table.pdf")
+
+  (is (thrown? Exception (pdf->bytes [{}
+                                      [:table {:widths [1 2]}
+                                       [[:cell "foo"]]]])))
+  (is (thrown? Exception (pdf->bytes [{}
+                                      [:table {:widths [1 2]}
+                                       [[:cell {:colspan 2} "foo"] "bar"]]])))
+  (is (some? (pdf->bytes [{}
+                          [:table {:widths [1 2]}
+                           [[:cell {:colspan 2} "foo"]]]])))
+  (is (some? (pdf->bytes [{}
+                          [:table {:widths [1 2]}
+                           ["foo" "bar"]]]))))
 
 (deftest line
   (eq? [{} [:line]]


### PR DESCRIPTION
When widths are specified, the number of columns declared in widths
has to match the maximum number of columns in a row.
Cells having colspan set, were counted as taking up a single column.

This fixes issue #242.
