### PR TITLE
chapter render method improvement

### DIFF
--- a/src/clj/clj_pdf/section/core.clj
+++ b/src/clj/clj_pdf/section/core.clj
@@ -39,10 +39,16 @@
   ([_ title text] (new Annotation title text)))
 
 (defmethod render :chapter
-  [tag meta & [title & sections]]
+  [tag meta & [title & {:keys [sections
+                               chap-content]
+                        :as args}]]
   (let [ch (new ChapterAutoNumber (make-section-or :paragraph meta title))]
-    (doseq [section (flatten-seqs sections)]
-      (make-section (assoc meta :parent ch) section))
+    (when chap-content
+      (doseq [content chap-content]
+        (.add ch (make-section-or :chunk meta content))))
+    (when sections
+      (doseq [section (flatten-seqs sections)]
+        (make-section (assoc meta :parent ch) section)))
     ch))
 
 


### PR DESCRIPTION
Allow user to add text in between the chapter title and the first section.
example:

`[:chapter [:paragraph {:size  20} "Introduction"]
    :chap-content
    (concat
     [[:spacer 2]]
     [[:paragraph "xxxxx"]]
     [[:list {:symbol "- "}
       "xxx"
       "xxxx"
       "xxxxx"]])]`
