### PR TITLE
Redo capitalization to make for correct code, text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,83 @@
-# `clj-pdf` [![coverage status](https://coveralls.io/repos/yogthos/clj-pdf/badge.svg?branch=master)](https://coveralls.io/r/yogthos/clj-pdf?branch=master) [![downloads](https://jarkeeper.com/yogthos/clj-pdf/downloads.svg)](https://jarkeeper.com/yogthos/clj-pdf)
+# `clj-pdf` [![Coverage Status](https://coveralls.io/repos/yogthos/clj-pdf/badge.svg?branch=master)](https://coveralls.io/r/yogthos/clj-pdf?branch=master) [![Downloads](https://jarkeeper.com/yogthos/clj-pdf/downloads.svg)](https://jarkeeper.com/yogthos/clj-pdf)
 
 
-a library for easily generating pdfs from clojure. an example pdf is available [here](https://github.com/yogthos/clj-pdf/raw/master/example.pdf) with its source [below](#a-complete-example).
+A library for easily generating PDFs from Clojure. An example PDF is available [here](https://github.com/yogthos/clj-pdf/raw/master/example.pdf) with its source [below](#a-complete-example).
 
-<!-- start doctoc generated toc please keep comment here to allow auto update -->
-<!-- don't edit this section, instead re-run doctoc to update -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **table of contents**  *generated with [doctoc](https://github.com/thlorenz/doctoc)*
 
-  - [installation](#installation)
-  - [usage](#usage)
-    - [templating](#templating)
-    - [stylesheets](#stylesheets)
-  - [document elements](#document-elements)
-  - [document format](#document-format)
-    - [metadata](#metadata)
-      - [font](#font)
-      - [using custom ttf fonts](#using-custom-ttf-fonts)
-    - [document sections](#document-sections)
-      - [anchor](#anchor)
-      - [chapter](#chapter)
-      - [chunk](#chunk)
-      - [clear double page](#clear-double-page)
-      - [graphics](#graphics)
-      - [heading](#heading)
-      - [image](#image)
-      - [line](#line)
-      - [list](#list)
-      - [multi-column](#multi-column)
-      - [pagebreak](#pagebreak)
-      - [paragraph](#paragraph)
-      - [phrase](#phrase)
-      - [reference](#reference)
-      - [section](#section)
-      - [spacer](#spacer)
-      - [string](#string)
-      - [subscript](#subscript)
-      - [superscript](#superscript)
-      - [svg](#svg)
-      - [table](#table)
-      - [pdf table](#pdf-table)
-      - [table cell](#table-cell)
-      - [pdf table cell](#pdf-table-cell)
-    - [charting](#charting)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Templating](#templating)
+    - [Stylesheets](#stylesheets)
+  - [Document Elements](#document-elements)
+  - [Document Format](#document-format)
+    - [Metadata](#metadata)
+      - [Font](#font)
+      - [Using Custom TTF Fonts](#using-custom-ttf-fonts)
+    - [Document sections](#document-sections)
+      - [Anchor](#anchor)
+      - [Chapter](#chapter)
+      - [Chunk](#chunk)
+      - [Clear double page](#clear-double-page)
+      - [Graphics](#graphics)
+      - [Heading](#heading)
+      - [Image](#image)
+      - [Line](#line)
+      - [List](#list)
+      - [Multi-Column](#multi-column)
+      - [Pagebreak](#pagebreak)
+      - [Paragraph](#paragraph)
+      - [Phrase](#phrase)
+      - [Reference](#reference)
+      - [Section](#section)
+      - [Spacer](#spacer)
+      - [String](#string)
+      - [Subscript](#subscript)
+      - [Superscript](#superscript)
+      - [SVG](#svg)
+      - [Table](#table)
+      - [PDF Table](#pdf-table)
+      - [Table Cell](#table-cell)
+      - [PDF Table Cell](#pdf-table-cell)
+    - [Charting](#charting)
       - [bar chart](#bar-chart)
       - [line chart](#line-chart)
       - [pie chart](#pie-chart)
-    - [a complete example](#a-complete-example)
-    - [using cell event callbacks](#using-cell-event-callbacks)
-  - [extensibility](#extensibility)
-- [users](#users)
-- [license](#license)
+    - [A complete example](#a-complete-example)
+    - [Using Cell Event Callbacks](#using-cell-event-callbacks)
+- [Extensibility](#extensibility)
+- [Users](#users)
+  - [Related Libraries](#related-libraries)
+- [License](#license)
 
-<!-- end doctoc generated toc please keep comment here to allow auto update -->
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## installation
+## Installation
 
 `clj-pdf` is available as a maven artifact from [clojars](https://clojars.org/search?q=clj-pdf):
 
-[![clojars project](http://clojars.org/clj-pdf/latest-version.svg)](http://clojars.org/clj-pdf)
+[![Clojars Project](http://clojars.org/clj-pdf/latest-version.svg)](http://clojars.org/clj-pdf)
 
-## usage
+## Usage
 
-pdf documents are generated calling the `pdf` function, defined in the `clj-pdf.core` namespace, with
+PDF documents are generated calling the `pdf` function, defined in the `clj-pdf.core` namespace, with
 input and output parameters.
 
 `(pdf in out)`
 
-`in` can be either a vector containing the document or an input stream. if `in` is an input stream then the forms will be read sequentially from it.
+`in` can be either a vector containing the document or an input stream. If `in` is an input stream then the forms will be read sequentially from it.
 
 `out` can be either a string, in which case it's treated as a file name, or an output stream.
 
-note: using the `:pages` option will cause the complete document to reside in memory for post processing.
+NOTE: using the `:pages` option will cause the complete document to reside in memory for post processing.
 
 
-the documents contain a map with metadata followed by one or more elements. each element must be a sequence starting with
+The documents contain a map with metadata followed by one or more elements. Each element must be a sequence starting with
 a keyword specifying the element name or a string which will be treated as a paragraph.
 
-here's a basic example of a document:
+Here's a basic example of a document:
 ```clojure
 (ns example
   (:use clj-pdf.core))
@@ -92,43 +93,43 @@ here's a basic example of a document:
    [:paragraph "yet more text"]]
   "doc.pdf")
 ```
-and the resulting pdf output
+and the resulting PDF output
 <br/>
 <img src="https://raw.github.com/yogthos/clj-pdf/master/example.png" hspace="20" alt="example"/>
 
-multiple documents can be combined into a single pdf using the `clj-pdf.core/collate` function.
-the function accepts an output stream followed by two or more documents. the documents can be one
-of inputstream, file name, url, or a byte array.
+Multiple documents can be combined into a single PDF using the `clj-pdf.core/collate` function.
+The function accepts an output stream followed by two or more documents. The documents can be one
+of InputStream, file name, URL, or a byte array.
 
 ```clojure
-(def doc1 (java.io.bytearrayoutputstream.))
-(def doc2 (java.io.bytearrayoutputstream.))
-(def doc3 (java.io.bytearrayoutputstream.))
+(def doc1 (java.io.ByteArrayOutputStream.))
+(def doc2 (java.io.ByteArrayOutputStream.))
+(def doc3 (java.io.ByteArrayOutputStream.))
 
 (pdf [{} "first document"] doc1)
 (pdf [{} "second document"] doc2)
-(pdf [{} "third document"] doc3)
+(pdf [{} "third document"] doc2)
 
-(collate (java.io.fileoutputstream. (clojure.java.io/file "merged.pdf"))
-         (.tobytearray doc1)
-         (.tobytearray doc2)
-         (.tobytearray doc3))
+(collate (java.io.FileOutputStream. (clojure.java.io/file "merged.pdf"))
+         (.toByteArray doc1)
+         (.toByteArray doc1)
+         (.toByteArray doc1))
 
 ;;all keys in the options map are optional
-(collate {:title "collated documents"
-          :author "john doe"
-          :creator "jane doe"
+(collate {:title "Collated Documents"
+          :author "John Doe"
+          :creator "Jane Doe"
           :keywords "jane,school,notes"
           :orientation :landscape
           :size :a4
-          :subject "some subject"}
-         (java.io.fileoutputstream. (clojure.java.io/file "merged.pdf"))
-         (.tobytearray doc1)
-         (.tobytearray doc2)
-         (.tobytearray doc3))
+          :subject "Some subject"}
+         (java.io.FileOutputStream. (clojure.java.io/file "merged.pdf"))
+         (.toByteArray doc1)
+         (.toByteArray doc1)
+         (.toByteArray doc1))
 ```
 
-sequences containing elements will be expanded into the document:
+Sequences containing elements will be expanded into the document:
 
 ```clojure
 (pdf
@@ -147,8 +148,8 @@ is equivalent to
  "doc.pdf")
 ```
 
-since `clj-pdf` uses regular clojure vectors you can easily add your own helper functions as well.
-for example, a `pdf-table` is expected to have the following format:
+Since `clj-pdf` uses regular Clojure vectors you can easily add your own helper functions as well.
+For example, a `pdf-table` is expected to have the following format:
 
 ```clojure
 [:pdf-table
@@ -157,7 +158,7 @@ for example, a `pdf-table` is expected to have the following format:
   [[:pdf-cell "foo"] [:pdf-cell "foo"] [:pdf-cell "foo"]]
   [[:pdf-cell "foo"] [:pdf-cell "foo"] [:pdf-cell "foo"]]]
 ```
-we can add a helper generate the expected format from the given data:
+We can add a helper generate the expected format from the given data:
 
 ```clojure
 (defn pdf-table [column-widths & rows]
@@ -172,25 +173,25 @@ we can add a helper generate the expected format from the given data:
   ["foo" "foo" "foo"])
 ```
 
-### templating
+### Templating
 
-the library provides some rudimentary templating options, the `template` macro can be used to generate a function which accepts a sequence of maps,
-and applies the template to each item. this is primarily meant to complement working with [clojure.java.jdbc](https://github.com/clojure/java.jdbc/),
+The library provides some rudimentary templating options, the `template` macro can be used to generate a function which accepts a sequence of maps,
+and applies the template to each item. This is primarily meant to complement working with [clojure.java.jdbc](https://github.com/clojure/java.jdbc/),
 which returns sequences of maps representing the table rows.
 
-the $ is used to indicate the anchors in the template. these will be swapped with the values from the map with
-the corresponding keys. for example, given a vector of maps, such as:
+The $ is used to indicate the anchors in the template. These will be swapped with the values from the map with
+the corresponding keys. For example, given a vector of maps, such as:
 
 ```clojure
 (def employees
-  [{:country "germany",
-    :place "nuremberg",
-    :occupation "engineer",
-    :name "neil chetty"}
-   {:country "germany",
-    :place "ulm",
-    :occupation "engineer",
-    :name "vera ellison"}])
+  [{:country "Germany",
+    :place "Nuremberg",
+    :occupation "Engineer",
+    :name "Neil Chetty"}
+   {:country "Germany",
+    :place "Ulm",
+    :occupation "Engineer",
+    :name "Vera Ellison"}])
 ```
 and a template
 ```clojure
@@ -209,36 +210,36 @@ the following output will be produced when the template is applied to the data:
 
 =>
 
-'([:paragraph [:heading "neil chetty"]
-   [:chunk {:style :bold} "occupation: "] "engineer" "\n"
-   [:chunk {:style :bold} "place: "] "nuremberg" "\n"
-   [:chunk {:style :bold} "country: "] "germany" [:spacer]]
-  [:paragraph [:heading "vera ellison"]
-   [:chunk {:style :bold} "occupation: "] "engineer" "\n"
-   [:chunk {:style :bold} "place: "] "ulm" "\n"
-   [:chunk {:style :bold} "country: "] "germany" [:spacer]])
+'([:paragraph [:heading "Neil Chetty"]
+   [:chunk {:style :bold} "occupation: "] "Engineer" "\n"
+   [:chunk {:style :bold} "place: "] "Nuremberg" "\n"
+   [:chunk {:style :bold} "country: "] "Germany" [:spacer]]
+  [:paragraph [:heading "Vera Ellison"]
+   [:chunk {:style :bold} "occupation: "] "Engineer" "\n"
+   [:chunk {:style :bold} "place: "] "Ulm" "\n"
+   [:chunk {:style :bold} "country: "] "Germany" [:spacer]])
 ```
 
-it is also possible to apply post processing to the anchors in the template:
+It is also possible to apply post processing to the anchors in the template:
 ```clojure
 (def employee-template-paragraph
   (template
     [:paragraph
-     [:heading (if (and $name (.startswith $name "alfred"))
-                 (.touppercase $name) $name)]
+     [:heading (if (and $name (.startsWith $name "Alfred"))
+                 (.toUpperCase $name) $name)]
      [:chunk {:style :bold} "occupation: "] $occupation "\n"
      [:chunk {:style :bold} "place: "] $place "\n"
      [:chunk {:style :bold} "country: "] $country
      [:spacer]]))
 ```
 
-### stylesheets
+### Stylesheets
 
-to use a css-like stylesheet, you can create a stylesheet map of class names.
-each class name will have an associated attribute map.  a specific stylesheet
+To use a CSS-like stylesheet, you can create a stylesheet map of class names.
+Each class name will have an associated attribute map.  A specific stylesheet
 must be included in the document metadata map in order to use it.
 
-use the css-like shortcut for applying classes to elements (e.g. `[:paragraph.foo.bar]`):
+Use the CSS-like shortcut for applying classes to elements (e.g. `[:paragraph.foo.bar]`):
 
 ```clojure
 (def stylesheet
@@ -256,52 +257,52 @@ use the css-like shortcut for applying classes to elements (e.g. `[:paragraph.fo
  "doc.pdf")
 ```
 
-## document elements
+## Document Elements
 
-[anchor](#anchor),
-[chapter](#chapter),
-[chart](#charting),
-[chunk](#chunk),
-[clear double page](#clear-double-page),
-[graphics](#graphics),
-[heading](#heading),
-[image](#image),
-[line](#line),
-[list](#list),
-[multi-column](#multi-column),
-[pagebreak](#pagebreak),
-[paragraph](#paragraph),
-[phrase](#phrase),
-[reference](#reference),
-[section](#section),
-[spacer](#spacer),
-[string](#string),
-[subscript](#subscript),
-[superscript](#superscript),
-[svg](#svg),
-[table](#table),
-[table cell](#table-cell)
+[Anchor](#anchor),
+[Chapter](#chapter),
+[Chart](#charting),
+[Chunk](#chunk),
+[Clear double page](#clear-double-page),
+[Graphics](#graphics),
+[Heading](#heading),
+[Image](#image),
+[Line](#line),
+[List](#list),
+[Multi-Column](#multi-column),
+[Pagebreak](#pagebreak),
+[Paragraph](#paragraph),
+[Phrase](#phrase),
+[Reference](#reference),
+[Section](#section),
+[Spacer](#spacer),
+[String](#string),
+[Subscript](#subscript),
+[Superscript](#superscript),
+[SVG](#svg),
+[Table](#table),
+[Table Cell](#table-cell)
 
-## document format
+## Document Format
 
-### metadata
+### Metadata
 
-all fields in the metadata section are optional:
+All fields in the metadata section are optional:
 
 ```clojure
-{:title  "test doc"
+{:title  "Test doc"
  :left-margin   10
  :right-margin  10
  :top-margin    20
  :bottom-margin 25
- :subject "some subject"
+ :subject "Some subject"
  :size          :a4
  :orientation   :landscape
  :keywords "those,metadata,keywords,comma,separated,help,with,searching"
- :author "john doe"
- :creator "jane doe"
+ :author "John Doe"
+ :creator "Jane Doe"
  :font  {:size 11} ;specifies default font
- :doc-header ["inspired by" "william shakespeare"]
+ :doc-header ["inspired by" "William Shakespeare"]
 
  ;;add custom hooks for document events
  :on-document-open (fn [^PdfWriter writer ^Document doc] ...)
@@ -316,23 +317,23 @@ all fields in the metadata section are optional:
  :on-section-end (fn [^PdfWriter writer ^Document doc ^float position] ...)
 
  ;;a watermark can be specified as an image or a function that
- ;;takes the graphics2d context and render an image on it
+ ;;takes the Graphics2D context and render an image on it
  ;;the watermark will be automatically applied to each page in the document
  ;;optionally the watermark can be rotated, scaled, and translated
  :watermark
  {:image "watermark.jpg"
   ;; :image and :render keys are exclusive, :render is preferred
-  :render (fn [g2d] (.drawString g2d "draft copy" 0 0))
+  :render (fn [g2d] (.drawString g2d "DRAFT COPY" 0 0))
   :translate [100 200]
   :rotate 45
   :scale 8}
 
- :header "page header text appears on each page"
- :letterhead ["a simple letter head"] ;sequence of any elements. if set, the first page shows letterhead instead of header
+ :header "Page header text appears on each page"
+ :letterhead ["A simple Letter head"] ;Sequence of any elements. If set, the first page shows letterhead instead of header
 
  ;;setting :footer to false will pevent page numbers from being displayed
  ;; the :footer also accepts a map containing a table for complex footer layouts as seen in the next section
- :footer {:text "page footer text appears on each page (includes page number)"
+ :footer {:text "Page footer text appears on each page (includes page number)"
           :align :left ;optional footer alignment of :left|:right|:center defaults to :right
           :footer-separator "text which will be displayed between current page number and total pages, defaults to /"
           :start-page 2 ;optional parameter to indicate on what page the footer starts, has no effect when :pages is set to false
@@ -348,7 +349,7 @@ all fields in the metadata section are optional:
  :references {:batman [:image "batman.jpg"]
               :superman [:image "superman.png"]}
 
- ;; register ttf fonts in some probable directories, set this to true if
+ ;; Register TTF fonts in some probable directories, set this to true if
  ;; you're going to use :ttf-name to set custom system fonts
  :register-system-fonts? true
 
@@ -375,7 +376,7 @@ all fields in the metadata section are optional:
 }
 ```
 
-the `:header` and `:footer` keys can also point to a `:table` element. the `:table` key
+The `:header` and `:footer` keys can also point to a `:table` element. The `:table` key
 must point to a `:pdf-table` type element:
 
 ```clojure
@@ -385,15 +386,15 @@ must point to a `:pdf-table` type element:
           [:pdf-table
            {:border false}
            [20 15 60]
-           ["this is a table header" "second column" "third column"]]}
+           ["This is a table header" "second column" "third column"]]}
  :footer {:table
           [:pdf-table
            {:border false}
            [20 15 60]
-           ["this is a table footer" "second column" "third column"]]}
+           ["This is a table footer" "second column" "third column"]]}
 ```
 
-the `:x` and `:y` keys can be used on the header and footer when using the `:table` key to specify the x/y offset on the page explicitly.
+The `:x` and `:y` keys can be used on the header and footer when using the `:table` key to specify the x/y offset on the page explicitly.
 
 available page sizes:
 
@@ -451,21 +452,21 @@ available page sizes:
 :tabloid
 ```
 
-alternatively, explicit page size can also be specified using a vector, eg:
+Alternatively, explicit page size can also be specified using a vector, eg:
 
 ```clojure
 :size [1296 1296]
 ```
-the size defaults to a4 page size if none is provided.
+The size defaults to A4 page size if none is provided.
 
-orientation defaults to portrait, unless `:landscape` is specified.
+Orientation defaults to portrait, unless `:landscape` is specified.
 
-#### font
+#### Font
 
-a font is defined by a map consisting of the following parameters, all parameters are optional
+A font is defined by a map consisting of the following parameters, all parameters are optional
 
 * :family has following options: :courier, :helvetica, :times-roman, :symbol, :zapfdingbats defaults to :helvetica
-* :ttf-name is the name of a ttf font installed on the system. overrides :family parameter. it could be an absolute or relative path to a font file; it will also seek for a font in classpath resources.
+* :ttf-name is the name of a TTF font installed on the system. Overrides :family parameter. It could be an absolute or relative path to a font file; it will also seek for a font in classpath resources.
 * :encoding should be set to :unicode to enable unicode support if custom :ttf-name font is used
 * :size is a number default is 10
 * :style has following options: :bold, :italic, :bold-italic, :normal, :strikethru, :underline defaults to :normal
@@ -483,32 +484,32 @@ example font:
  {:styles [:bold :underline]
   :family :helvetica}
 ```
-note: font styles are additive, for example setting style :italic on the phrase, and then size 20 on a chunk inside the phrase, will result with the chunk having italic font of size 20. inner elements can override style set by their parents.
+note: Font styles are additive, for example setting style :italic on the phrase, and then size 20 on a chunk inside the phrase, will result with the chunk having italic font of size 20. Inner elements can override style set by their parents.
 
-#### using custom ttf fonts
+#### Using Custom TTF Fonts
 
-for non-ascii text output you will probably have to use external font and define `:encoding` as `:unicode`.
+For non-ASCII text output you will probably have to use external font and define `:encoding` as `:unicode`.
 
-the following example illustrates how to specify a custom font file such as cyrillic font.
+The following example illustrates how to specify a custom font file such as Cyrillic font.
 
 ```clojure
 (pdf
   [{:font {:encoding :unicode
-           :ttf-name "fonts/arialuni.ttf"}}
+           :ttf-name "fonts/Arialuni.ttf"}}
   [:phrase "тест 123"]]
   "doc.pdf")
 ```
 
-custom fonts can also be specified for any elements that support font metadata, such as phrases and paragraphs:
+Custom fonts can also be specified for any elements that support font metadata, such as phrases and paragraphs:
 
 ```clojure
 [:paragraph
-   {:encoding "unijis-ucs2-h"
-    :ttf-name "heiseikakugo-w5"}
+   {:encoding "UniJIS-UCS2-H"
+    :ttf-name "HeiseiKakuGo-W5"}
    "こんにちは世界"]
 ```
 
-you could set `:ttf-name` as absolute or relative path to the font file. it will also load fonts from classpath resources by default.
+You could set `:ttf-name` as absolute or relative path to the font file. It will also load fonts from classpath resources by default.
 
 Phrases also support font-stacks: For each character, the first ttf-name in the
 supplied font-stack sequence is chosen, that supports it.  
@@ -520,12 +521,11 @@ a child element.
  {:size 14 :font-stack ["fonts/fancy_font.ttf" "fonts/arialuni.ttf"]}
  "mixed scripts тест 123"]
 ```
+### Document sections
 
-### document sections
+Each document section is represented by a vector starting with a keyword identifying the section followed by an optional map of metadata and the contents of the section.
 
-each document section is represented by a vector starting with a keyword identifying the section followed by an optional map of metadata and the contents of the section.
-
-#### anchor
+#### Anchor
 
 tag :anchor
 
@@ -549,16 +549,16 @@ idiosynchorsies:
 ```clojure
 [:anchor {:target "http://google.com"} "google"]
 
-[:anchor {:style {:size 15} :leading 20 :id "targetanchor"} "some anchor"]
+[:anchor {:style {:size 15} :leading 20 :id "targetAnchor"} "some anchor"]
 
-[:anchor {:target "#targetanchor"} "this anchor points to some anchor"]
+[:anchor {:target "#targetAnchor"} "this anchor points to some anchor"]
 
 [:anchor [:phrase {:style :bold} "some anchor phrase"]]
 
 [:anchor "plain anchor"]
 ```
 
-#### chapter
+#### Chapter
 
 tag :chapter
 
@@ -572,12 +572,12 @@ content:
 * paragraph
 
 ```clojure
-[:chapter "first chapter"]
+[:chapter "First Chapter"]
 
-[:chapter [:paragraph "second chapter"]]
+[:chapter [:paragraph "Second Chapter"]]
 ```
 
-#### chunk
+#### Chunk
 
 tag :chunk
 
@@ -588,7 +588,7 @@ optional metadata:
 * :underlines sequence of underlines to add, e.g.
     `[{:thickness 5 :y-position 7} {:thickness 2 :y-position -7}]`
 
-font metadata (refer to font section for details)
+font metadata (refer to Font section for details)
 
 * :family
 * :ttf-name
@@ -598,7 +598,7 @@ font metadata (refer to font section for details)
 * :color
 * :background [r b g]
 
-note that when using `:ttf-name`, you should set `:register-system-fonts? true` in the document metadata in order to load the available system fonts, or manually provide paths to the font files.
+Note that when using `:ttf-name`, you should set `:register-system-fonts? true` in the document metadata in order to load the available system fonts, or manually provide paths to the font files.
 
 ```clojure
 [:chunk {:style :bold} "small chunk of text"]
@@ -614,14 +614,14 @@ note that when using `:ttf-name`, you should set `:register-system-fonts? true` 
 [:chunk {:sub true} "2"]
 ```
 
-#### clear double page
+#### Clear double page
 
 tag :clear-double-page
 
-ends current page and inserts a blank page if necessary to ensure that subsequent content starts on the next odd-numbered page. in other words, if you print the resulting pdf on double-sided paper, the content that comes after a `:clear-double-page` will always be on a different sheet of paper from the content that came before it.
+Ends current page and inserts a blank page if necessary to ensure that subsequent content starts on the next odd-numbered page. In other words, if you print the resulting PDF on double-sided paper, the content that comes after a `:clear-double-page` will always be on a different sheet of paper from the content that came before it.
 
 ```clojure
-;; example documents
+;; Example documents
 
 [[:paragraph "this is on page 1"] [:clear-double-page] [:paragraph "this is on page 3"]]
 
@@ -639,17 +639,17 @@ ends current page and inserts a blank page if necessary to ensure that subsequen
  [:paragraph "this is on page 5"]]
 
 ;; :clear-double-page on an empty page 1 does nothing
-[[:clear-double-page] [:paragraph "this is on page 1"]]
+[[:clear-double-page] [:paragraph "This is on page 1"]]
 ```
 
-#### graphics
+#### Graphics
 
 tag :graphics
 
-the command takes a function with a single argument, the [graphics2d](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) object, onto which you can draw
-things. note that this is actually a [*pdfgraphics2d*](https://librepdf.github.io/OpenPDF/docs-1-3-17/com/lowagie/text/pdf/PdfGraphics2D.html) object (a subclass of
-graphics2d) which will render the drawing instructions as vectors rather than to a raster bitmap. there is no need to dispose of the graphics context as this is done on
-exiting the function.  the co-ordinates are absolute from the top left hand side of the current page. there are no restrictions as to the number of times this command can
+The command takes a function with a single argument, the [graphics2d](https://docs.oracle.com/javase/8/docs/api/java/awt/Graphics2D.html) object, onto which you can draw
+things. Note that this is actually a [*pdfgraphics2d*](https://librepdf.github.io/OpenPDF/docs-1-3-17/com/lowagie/text/pdf/PdfGraphics2D.html) object (a subclass of
+graphics2d) which will render the drawing instructions as vectors rather than to a raster bitmap. There is no need to dispose of the graphics context as this is done on
+exiting the function. The co-ordinates are absolute from the top left hand side of the current page. There are no restrictions as to the number of times this command can
 be invoked per page; subsequent graphics drawings will be overlaid on prior renderings.
 
 The font system for `.setFont` is different than that used in the rest of `clj-pdf`. Enabling `:register-system-fonts? true` in the document metadata will also register


### PR DESCRIPTION
Somehow, pr #140 lowercased every letter in README.md. This not only made for somewhat more confusing text, but also broke some of the code examples. One such case:

```
(def doc1 (java.io.bytearrayoutputstream.))
```

This code isn't even able to run, because java.io doesn't have a class `bytearrayoutputstream`. It has a `ByteArrayOutputstream`, which differs only in case.

So this PR fixes the capitalization back to what it was before the change [here]https://github.com/clj-pdf/clj-pdf/commit/8c51b2d7cc88795d5b4dc5824ebe5e261917482a#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), keeping any changes to the readme since that commit. I also reran doctoc.